### PR TITLE
Updated Config file and ReadMe

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -2,8 +2,8 @@
 
 const Config = {
   loginUrl: 'https://login.salesforce.com/services/oauth2/authorize?',
-  consumerKey: 'your-oauth-consumer-key',
-  oauthRedirect: 'https://localhost:8443/oauth-redirect'
+  consumerKey: '{your-oauth-consumer-key}',
+  oauthRedirect: 'https://{your-domain}/oauth-redirect'
 }
 
 export default Config

--- a/Config.js
+++ b/Config.js
@@ -1,9 +1,9 @@
 // Update with configuration for your org and connected app.
 
 const Config = {
-  loginUrl: 'https://www.salesforce.com/services/oauth2/authorize?',
+  loginUrl: 'https://login.salesforce.com/services/oauth2/authorize?',
   consumerKey: 'your-oauth-consumer-key',
-  oauthRedirect: 'https://www.your-domain.com/oauth-redirect'
+  oauthRedirect: 'https://localhost:8443/oauth-redirect'
 }
 
 export default Config

--- a/README.md
+++ b/README.md
@@ -1,14 +1,25 @@
-# ReactNativeViewer
-React Native Record Viewer
+# Record Viewer&mdash;React Native
 
-# Setup
-Edit Config.js to set:
-- Salesforce instance endpoint
-- OAuth consumer key
-- OAuth redirect URI (can be fake, not really visited)
+This React Native app shows you how easy it is to use the Salesforce [User Interface API](https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi) to create, read, update, and delete Salesforce records.
 
-# Build
-- Install react-native, watchman, XCode
-- Clone repository
-- Run "npm install"
-- Run "react-native run-ios" (Android build might work but is untested)
+Salesforce uses User Interface API to build the Salesforce1 and Lightning Experience apps. Not only do you get data and metadata in a single response, but the response matches metadata changes made to the org by Salesforce admins. You don’t have to worry about layouts, picklists, field-level security, or sharing&mdash;all you have to do is build an app that users love.
+
+## Set Up the App
+
+The Record Viewer app gets and sets data from a Salesforce organization.
+
+To authenticate Record Viewer with a Salesforce org:
+
+1. In the Salesforce org, [configure a connected app](https://help.salesforce.com/articleView?id=connected_app_overview.htm).
+    * For the Callback URL, enter `https://localhost:8443/oauth-redirect`.
+    * Make a note of the OAuth consumer key to enter in the Record Viewer Config.js file.
+
+1. Clone the RecordViewerNative repository.
+1. Open the Config.js file and set the OAuth consumer key.
+
+## Build the App
+
+1. Install `react-native`, `watchman`, and `XCode`.
+1. From the RecordViewerNative directory:
+    1. Run `npm install`.
+    1. Run `react-native run-ios`. (The Android build might work, but we haven't tested it.)

--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ The Record Viewer app gets and sets data from a Salesforce organization.
 To authenticate Record Viewer with a Salesforce org:
 
 1. In the Salesforce org, [configure a connected app](https://help.salesforce.com/articleView?id=connected_app_overview.htm).
-    * For the Callback URL, enter `https://localhost:8443/oauth-redirect`.
+    * For the Callback URL, enter any URL that starts with `https://`.
     * Make a note of the OAuth consumer key to enter in the Record Viewer Config.js file.
 
 1. Clone the RecordViewerNative repository.
-1. Open the Config.js file and set the OAuth consumer key.
+1. In the Config.js file:
+   * Set the callback URL to match the value in the connected app. 
+   * Set the OAuth consumer key to match the value in the connected app.
+   
 
 ## Build the App
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ To authenticate Record Viewer with a Salesforce org:
 
 1. Clone the RecordViewerNative repository.
 1. In the Config.js file:
-   * Set the callback URL to match the value in the connected app. 
-   * Set the OAuth consumer key to match the value in the connected app.
+   * Set `oauthRedirect` to the callback URL in the connected app. 
+   * Set `consumerKey` to the OAuth consumer key in the connected app.
    
 
 ## Build the App


### PR DESCRIPTION
I was able to authorize only when I used the callback URL `https://localhost:8443/oauth-redirect`. Will that be true for everyone? If so, we should hardcode the callback in Config.js. If not, I need to change that string back to `https://www.your-domain.com/oauth-redirect`.

